### PR TITLE
Clarify explanation of operator precedence

### DIFF
--- a/book/haskell-basics/operators.md
+++ b/book/haskell-basics/operators.md
@@ -62,7 +62,7 @@ associates to the left. This means the following expression:
 2 + 2 * 6
 ```
 
-would normally be parsed as
+would normally be treated as
 
 ```haskell
 (((2 +) 2) * 6)


### PR DESCRIPTION
"`2 + 2 * 6` is equal to `(((2 +) 2) * 6)`" instead of "is parsed as"
