### PR TITLE
Fix a typo and an incorrect "it's"

### DIFF
--- a/book/applicative/follow-the-types.md
+++ b/book/applicative/follow-the-types.md
@@ -47,7 +47,7 @@ expression to an equivalent one with less noise:
 User <$> getParam "name" params :: Maybe (String -> User)
 ```
 
-This expression represents a "`Maybe` function". We're accustom to *values* in a
+This expression represents a "`Maybe` function". We're accustomed to *values* in a
 context: a `Maybe Int`, `Maybe String`, etc; and we saw how these were
 *functors*. In this case, we have a *function* in a context: a `Maybe (String ->
 User)`. Since functions are things that *can be applied*, these are called

--- a/book/monad/bind.md
+++ b/book/monad/bind.md
@@ -1,6 +1,6 @@
 ## Bind
 
-If you haven't guessed it, Haskell does have exactly this function. It's name is
+If you haven't guessed it, Haskell does have exactly this function. Its name is
 *bind* and it's defined as part of the `Monad` type class. Here is its type
 signature:
 

--- a/book/monad/do.md
+++ b/book/monad/do.md
@@ -82,7 +82,7 @@ findUserShippingCost uid = do
     shippingCost z
 ```
 
-Et Violà, you have the equivalent *do-notation* version of our function. When
+Et voilà, you have the equivalent *do-notation* version of our function. When
 the compiler sees code written like this, it follows (mostly) the same process
 we did, but in reverse:
 


### PR DESCRIPTION
- accustom -> accustomed
- it's -> its
- viola -> voila
