### PR TITLE
Update why.md

### DIFF
--- a/book/functor/why.md
+++ b/book/functor/why.md
@@ -9,7 +9,7 @@ findUser :: UserId -> Maybe User
 findUser = undefined
 ```
 
-I've left the implementation of `findUser` as `undefined` because it doesn't
+I've left the implementation of `findUser` as `undefined` because this doesn't
 matter for our example. I'll do this frequently throughout the book. `undefined`
 is a function with type `a`. That allows it to stand in for any expression. If
 your program ever tries to evaluate it, it will raise an exception. Still, it
@@ -24,16 +24,16 @@ userUpperName u = map toUpper (userName u)
 ```
 
 The logic of getting from a `User` to that capitalized `String` is not terribly
-complex, but it could be -- imagine something like getting from a `User` to
-their yearly spending on products valued over $1,000. In our case the
+complex, but it could be. Imagine something like getting from a `User` to
+that user's yearly spending on products valued over $1,000. In our case the
 transformation is only one function, but realistically it could be a whole suite
 of functions wired together. Ideally, none of these functions should have to
-think about potential non-presence or contain any "nil-checks" as that's not
+think about potential non-presence or contain any "nil-checks," as that's not
 their purpose; they should all be written to work on values that are fully
 present.
 
 Given `userUpperName`, which works only on present values, we can use `fmap` to
-apply it to a value which may not be present to get back the result we expect
+apply it to a value that may not be present to get back the result we expect
 with the same level of *present-ness*:
 
 ```haskell
@@ -45,7 +45,7 @@ We can do this repeatedly with every function in our system that's required to
 get from `findUser` to the eventual display of this name. Because of the second
 functor law, we know that if we compose all of these functions together then
 `fmap` the result, or if we `fmap` any individual functions and compose the
-results, we'll always get the same answer. We're free to architect our system as
+results, we'll always get the same answer. We're free to design our system architecture as
 we see fit, but still pass along the `Maybe`s everywhere we need to.
 
 If we were doing this in the context of a web application, this maybe-name might


### PR DESCRIPTION
Mostly routine changes except for the instance of "architect" as a verb. Unless that has a very particular meaning in programming jargon, I'd prefer to translate what seems like a pretty clanking usage into more standard English.
