### PR TITLE
Update curried-form.md

### DIFF
--- a/book/functor/curried-form.md
+++ b/book/functor/curried-form.md
@@ -3,7 +3,7 @@
 Before moving on, I need to pause briefly and answer a question I dodged in the
 Haskell Basics chapter. You may have wondered why Haskell type signatures don't
 separate a function's argument types from its return type. The direct answer is
-that all functions in Haskell are in *curried* form; an idea developed by and
+that all functions in Haskell are in *curried* form. This is an idea developed by and
 named for the same [logician][] as Haskell itself.
 
 [logician]: http://en.wikipedia.org/wiki/Haskell_Curry
@@ -11,7 +11,7 @@ named for the same [logician][] as Haskell itself.
 A curried function is one that *conceptually* accepts multiple arguments by
 actually accepting only one, but returning a function. The returned function
 itself will also be curried and use the same process to accept more arguments.
-This process continues for as many arguments as needed. In short, all functions
+This process continues for as many arguments as are needed. In short, all functions
 in Haskell are of the form `(a -> b)`. A (conceptually) multi-argument function
 like `add :: Int -> Int -> Int` is really `add :: Int -> (Int -> Int)`; this
 matches `(a -> b)` by taking `a` as `Int` and `b` as `(Int -> Int)`.
@@ -20,14 +20,14 @@ The reason I didn't talk about this earlier is that we can mostly ignore it when
 writing Haskell code. We define and apply functions as if they actually accept
 multiple arguments and things work as we intuitively expect. Even partial
 application (a topic I hand-waved a bit at the time) can be used effectively
-without realizing it's a direct result of curried functions. It's when we dive
+without realizing this is a direct result of curried functions. It's when we dive
 into concepts like `Applicative` (the focus of the next chapter) that we need to
 understand a bit more about what's going on under the hood.
 
 ### The Case for Currying
 
 In the implementation of purely functional programming languages, there is value
-in all functions taking exactly one argument and returning exactly one result.
+in having all functions taking exactly one argument and returning exactly one result.
 Haskell is written this way, so users have two choices for defining
 "multi-argument" functions.
 
@@ -38,7 +38,7 @@ add :: (Int, Int) -> Int
 add (x, y) = x + y
 ```
 
-This results in type signatures you might expect, where the argument types are
+This results in the sort of type signatures you might expect, where the argument types are
 shown separate from the return types. The problem with this form is that partial
 application can be cumbersome. How do you add 5 to every element in a list?
 
@@ -77,7 +77,7 @@ f = map (add 5) [1,2,3]
 ```
 
 While both forms are valid Haskell (in fact, the `curry` and `uncurry` functions
-in the Prelude convert functions between the two forms), the latter was chosen
+in the Prelude convert functions between the two forms), the curried version was chosen
 as the default and so Haskell's syntax allows some things that make it more
 convenient.
 
@@ -127,16 +127,16 @@ And it has the same meaning as well.
 
 These conveniences are why we don't actively picture functions as curried when
 writing Haskell code. We can define `addThree` naturally, as if it took three
-arguments and the rules of the language handle currying. We can also apply
+arguments, and let the rules of the language handle currying. We can also apply
 `addThree` naturally, as if it took three arguments and again the rules of the
-language handle the currying.
+language will handle the currying.
 
 ### Partial Application
 
 Some languages don't use curried functions but do support *partial application*:
 supplying only some of a function's arguments to get back another function that
-accepts the arguments left out. We can do this in Haskell too, but it's not
-"partial" at all, since all functions truly only accept a single argument.
+accepts the arguments that were left out. We can do this in Haskell too, but it's not
+"partial" at all, since all functions truly accept only a single argument.
 
 When we wrote the following expression:
 
@@ -144,7 +144,7 @@ When we wrote the following expression:
 maybeName = fmap userUpperName (findUser someId)
 ```
 
-What really happened is `fmap` was first applied to the function `userUpperName`
+What really happened is that `fmap` was first applied to the function `userUpperName`
 to return a new function of type `Maybe User -> Maybe String`.
 
 ```haskell


### PR DESCRIPTION
Mostly minor stuff, with one substantive exception: I removed the phrase "the latter" in the eighth text paragraph. That's because "the latter" could easily be misread to refer to the parenthetical mention of the "curry and uncurry functions in the Prelude," which would have the opposite meaning to what the sentence's core is about. Please be sure I have interpreted your intention correctly.
